### PR TITLE
upgrade hugo version to v0.142 to activate googleAnalytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,9 +32,9 @@
     {{ with .OutputFormats.Get "RSS" }}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end }}
-    {{- if not .Site.IsServer -}}
+    {{ if not hugo.IsServer }}
       {{ template "_internal/google_analytics.html" . }}
-    {{- end -}}
+    {{ end }}
 
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ command = "hugo --gc --minify -b $URL"
 TZ = "Asia/Tokyo"
 
 [context.production.environment]
-HUGO_VERSION = "0.68.3"
+HUGO_VERSION = "0.142.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -14,20 +14,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.68.3"
+HUGO_VERSION = "0.142.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.68.3"
+HUGO_VERSION = "0.142.0"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.68.3"
+HUGO_VERSION = "0.142.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
This pull request includes several updates to improve the functionality and performance of the project. The most important changes include updating the Hugo version in various contexts, modifying the `head.html` template to use the correct server check function, and updating a submodule to a new commit.

### Updates and improvements:

* [`netlify.toml`](diffhunk://#diff-ab8f79b68b7adff7a07db953bf453f3c5aa6ade98d2b1b67d8432b36392489edL9-R30): Updated Hugo version from `0.68.3` to `0.142.0` in multiple contexts to ensure compatibility with the latest features and improvements.

### Template modifications:

* [`layouts/partials/head.html`](diffhunk://#diff-96dd75a968976edd5e03170268ed9085733f75c3fb24f992ae613c89e6de42dcL35-R37): Changed the server check function from `.Site.IsServer` to `hugo.IsServer` to fix a compatibility issue.

### Submodule update:

* [`themes/noteworthy`](diffhunk://#diff-8056624585ec875cf23d25bca623eacf5d6192861baa6da26ff94b16e0d1e606L1-R1): Updated the submodule commit to `53b4c98f207d22b5ff7734df466240d2fcc0ad9f` to include the latest changes from the submodule repository.- **update**
- **update**
- **update**
- **update**
- **add favicon**
- **update hugo version to v0.142**
