### PR TITLE
fix: restore OGP image tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,21 @@
     {{ with .OutputFormats.Get "RSS" }}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end }}
-    {{ partial "seo.html" . }}
+    <!-- SEO -->
+    <link rel="canonical" href="{{ .Permalink }}">
+    {{- $description := "" }}
+    {{- if .Description }}
+      {{- $description = .Description }}
+    {{- else if .IsPage }}
+      {{- $description = .Summary | plainify | truncate 200 }}
+    {{- else if .Site.Params.description }}
+      {{- $description = .Site.Params.description }}
+    {{- end }}
+    {{- with $description }}
+    <meta name="description" content="{{ . }}">
+    {{- end }}
+    {{ template "_internal/opengraph.html" . }}
+    {{ template "_internal/twitter_cards.html" . }}
 
     {{ if not hugo.IsServer }}
       {{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
## Summary

- テーマを最新master (edge2992/hugo-theme-noteworthy#30) に更新
- ブログ側の `layouts/partials/head.html` オーバーライドも Hugo 内部テンプレートに変更

## 背景

テーマ v0.1.0 で導入された `seo.html` が Hugo 標準と異なるパラメータ名 (`defaultOgImage`) を使用しており、`og:image` / `twitter:image` が出力されなくなっていた。

## 修正内容

- テーマ側: カスタム `seo.html` を削除し Hugo 内部テンプレートに戻す (edge2992/hugo-theme-noteworthy#30)
- ブログ側: `layouts/partials/head.html` の `{{ partial "seo.html" . }}` を Hugo 内部テンプレート呼び出しに変更

## 確認済み

- `hugo` ビルド成功
- トップページ・記事ページで `og:image`, `twitter:image` が正しく出力される

Closes #52